### PR TITLE
Split Bill Page and Profile Page Improvements

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,11 +1,29 @@
+import React, { useEffect } from 'react';
 import MainNavigator from './src/navigator/MainNavigator';
 import { store } from './src/store/store';
 import { Provider } from 'react-redux';
-import { LogBox } from 'react-native';
+import { LogBox, Image } from 'react-native';
+import {
+  onSnapshot,
+  collection,
+} from 'firebase/firestore';
+import { db } from './src/firebase/loginAPI';
 LogBox.ignoreLogs(['new NativeEventEmitter']); // Ignore log notification by message
 LogBox.ignoreAllLogs(); //Ignore all log notifications
 
 export default function App() {
+  useEffect(() => {
+    const unsubUserQuery = onSnapshot(collection(db, "users"), snapshot => {
+      snapshot.docs.forEach(doc => {
+          Image.prefetch(doc.data().photoURL);
+      });  
+    });
+
+    return () => {
+      unsubUserQuery();
+    }
+  }, []);
+
   return (
     <Provider store={store}>
       <MainNavigator />

--- a/package-lock.json
+++ b/package-lock.json
@@ -34785,7 +34785,6 @@
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.67.0.tgz",
       "integrity": "sha512-tgTG4j0SKwLHbLRELMmgkgkjV1biYkWlGGKOmM484/fJC6bpDikdaFhfjsyE+W+qt7I5szbCPCickMTNQ+zwig==",
       "requires": {
-        "@babel/core": "^7.14.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -34832,7 +34831,6 @@
       "resolved": "https://registry.npmjs.org/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.67.0.tgz",
       "integrity": "sha512-P0JT09n7T01epUtgL9mH6BPat3xn4JjBakl4lWHdL61cvEGcrxuIom1eoFFKkgU/K5AVLU4aCAttHS7nSFCcEQ==",
       "requires": {
-        "@babel/core": "^7.14.0",
         "babel-preset-fbjs": "^3.4.0",
         "hermes-parser": "0.5.0",
         "metro-babel-transformer": "0.67.0",

--- a/src/components/ActiveGroupContact.js
+++ b/src/components/ActiveGroupContact.js
@@ -3,12 +3,12 @@ import {
     View,
     Text,
     TouchableOpacity,
-    StyleSheet
+    StyleSheet,
+    Image
 } from 'react-native';
 import { useDispatch } from 'react-redux';
 import Checkbox from 'expo-checkbox';
 import { addActiveGroupMember, removeActiveGroupMember } from '../store/receiptSlice';
-import CachedImage from 'react-native-expo-cached-image';
 
 const ActiveGroupContact = ({ email, profileImg, activeGroupMembers }) => {
     const dispatch = useDispatch();
@@ -54,10 +54,10 @@ const ActiveGroupContact = ({ email, profileImg, activeGroupMembers }) => {
                 }
             }}>
             <View style={styles.contactContainer}>
-                <CachedImage
-                    isBackground 
+                <Image
                     source={{ uri: profileImg }}
                     style={styles.profileImg}
+                    cache="only-if-cached"
                 />
                 <Text style={styles.email}>
                     {email}

--- a/src/components/ActiveGroupContact.js
+++ b/src/components/ActiveGroupContact.js
@@ -67,8 +67,14 @@ const ActiveGroupContact = ({ email, profileImg, activeGroupMembers }) => {
             <Checkbox 
                 style={styles.checkBox}
                 value={isChecked}
-                onValueChange={setIsChecked}
                 color="rgb(10, 132, 255)"
+                onValueChange={() => {
+                    if (!isChecked) {
+                        addMember(email);
+                    } else {
+                        removeMember(email);
+                    }
+                }}
             />
         </TouchableOpacity>
     )

--- a/src/components/ActiveGroupContact.js
+++ b/src/components/ActiveGroupContact.js
@@ -32,7 +32,6 @@ const ActiveGroupContact = ({ email, profileImg, activeGroupMembers }) => {
             newMember: {
                 email: newMember,
                 items: [],
-                totalPrice: 0
             }
         }));
     };

--- a/src/components/AddItemModal.js
+++ b/src/components/AddItemModal.js
@@ -6,9 +6,8 @@ import {
     TouchableOpacity,
     View,
     TextInput,
-    TouchableWithoutFeedback,
-    Keyboard
 } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 const AddItemModal = ({
     isVisible,
@@ -26,7 +25,8 @@ const AddItemModal = ({
             isVisible={isVisible}
             onBackButtonPress={onClose}
             style={styles.modal}>
-            <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+            <KeyboardAwareScrollView
+                resetScrollToCoords={{ x: 0, y: 0 }}>
                 <View style={{ flex: 1 }}>
                     <View style={styles.topBar}>
                         <TouchableOpacity
@@ -84,7 +84,7 @@ const AddItemModal = ({
                             *All Fields Must Be Filled
                         </Text>
                         <Text style={hasError ? styles.error : styles.warning}>
-                            *Price Must Only Have At Most One Decimal
+                            *Quantity or Price invalid
                         </Text>
                         <TouchableOpacity
                             style={styles.addBtn}
@@ -106,7 +106,7 @@ const AddItemModal = ({
                         </TouchableOpacity>
                     </View>
                 </View>
-            </TouchableWithoutFeedback>
+            </KeyboardAwareScrollView>
         </Modal>
     )
 };

--- a/src/components/AddItemModal.js
+++ b/src/components/AddItemModal.js
@@ -84,7 +84,7 @@ const AddItemModal = ({
                             *All Fields Must Be Filled
                         </Text>
                         <Text style={hasError ? styles.error : styles.warning}>
-                            *Quantity or Price invalid
+                            *Quantity and Price must be valid
                         </Text>
                         <TouchableOpacity
                             style={styles.addBtn}

--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -3,17 +3,17 @@ import {
     View, 
     Text, 
     TouchableOpacity,
+    Image
 } from 'react-native';
-import CachedImage from 'react-native-expo-cached-image';
 
 const Contact = ({ item, profileImg }) => {
     return (
         <View style={styles.contact}>
             <View style={styles.userDisplay}>
-                <CachedImage
-                    isBackground
+                <Image
                     source={{ uri: profileImg }} 
-                    style={styles.contactImg} />
+                    style={styles.contactImg}
+                    cache="only-if-cached" />
                 <Text style={styles.name}>
                     {item.friend}
                 </Text>

--- a/src/components/ContactBill.js
+++ b/src/components/ContactBill.js
@@ -2,19 +2,18 @@ import {
     View,
     Text,
     StyleSheet,
-    FlatList
+    Image
 } from 'react-native';
 import HorizontalLine from './HorizontalLine';
-import CachedImage from 'react-native-expo-cached-image';
 
 const ContactBill = ({ member, profileImg }) => {
     return (
         <View style={styles.container}>
             <View style={styles.contactContainer}>
-                <CachedImage
-                    isBackground
+                <Image
                     source={{ uri: profileImg }}
                     style={styles.profilePic}
+                    cache="only-if-cached"
                 />
                 <Text style={styles.emailText}>
                     {member.email}

--- a/src/components/ContactBill.js
+++ b/src/components/ContactBill.js
@@ -42,7 +42,7 @@ const ContactBill = ({ member, profileImg }) => {
                         Total price:
                     </Text>
                     <Text style={styles.calculatedPrice}>
-                        ${member.totalPrice}
+                        ${member.totalPrice.toFixed(2)}
                     </Text>
                 </View>
             </View>

--- a/src/components/ContactSimple.js
+++ b/src/components/ContactSimple.js
@@ -2,17 +2,17 @@ import {
     StyleSheet, 
     View, 
     Text,
+    Image
 } from 'react-native';
-import CachedImage from 'react-native-expo-cached-image';
 
 const ContactSimple = ({ item, profileImg }) => {
     return (
         <View style={styles.contact}>
             <View style={styles.userDisplay}>
-                <CachedImage
-                    isBackground
+                <Image
                     source={{ uri: profileImg }} 
-                    style={styles.contactImg} />
+                    style={styles.contactImg}
+                    cache="only-if-cached" />
                 <Text style={styles.name}>
                     {item.friend}
                 </Text>

--- a/src/components/DeleteFriendBin.js
+++ b/src/components/DeleteFriendBin.js
@@ -10,11 +10,19 @@ import {
 } from 'firebase/firestore';
 import { db } from '../firebase/loginAPI';
 import DeleteFriendModal from './DeleteFriendModal';
+import ErrorMessageModal from './ErrorMessageModal';
 
 const DeleteFriendBin = ({ item }) => {
     const [isVisible, setIsVisible] = useState(false);
+    const [errorModalVisible, setErrorModalVisible] = useState(false);
 
     const deleteFriendHandler = async (id) => {
+        if (item.amount !== 0) {
+            setIsVisible(false);
+            setErrorModalVisible(true);
+            return;
+        }
+
         try {
             const docRef = doc(db, 'friendship', id);
             await deleteDoc(docRef);
@@ -36,6 +44,11 @@ const DeleteFriendBin = ({ item }) => {
                 isVisible={isVisible}
                 deleteFriendHandler={() => deleteFriendHandler(item.id)}
                 onClose={() => setIsVisible(false)}
+            />
+            <ErrorMessageModal
+                message="Clear debts before deleting friends"
+                isVisible={errorModalVisible}
+                onClose={() => setErrorModalVisible(false)}
             />
         </TouchableOpacity>
     )

--- a/src/components/EditItemModal.js
+++ b/src/components/EditItemModal.js
@@ -6,9 +6,8 @@ import {
     TouchableOpacity,
     View,
     TextInput,
-    TouchableWithoutFeedback,
-    Keyboard
 } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 
 const EditItemModal = ({
     isVisible,
@@ -28,7 +27,8 @@ const EditItemModal = ({
             isVisible={isVisible}
             onBackButtonPress={onClose}
             style={styles.modal}>
-            <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+            <KeyboardAwareScrollView
+                resetScrollToCoords={{ x: 0, y: 0 }}>
                 <View style={{ flex: 1 }}>
                     <View style={styles.topBar}>
                         <TouchableOpacity
@@ -113,7 +113,7 @@ const EditItemModal = ({
                         </View>
                     </View>
                 </View>
-            </TouchableWithoutFeedback>
+            </KeyboardAwareScrollView>
         </Modal>
     )
 };

--- a/src/components/EditItemModal.js
+++ b/src/components/EditItemModal.js
@@ -83,7 +83,7 @@ const EditItemModal = ({
                             *All Fields Must Be Filled
                         </Text>
                         <Text style={hasError? styles.error : styles.warning}>
-                            *Price Must Only Have At Most One Decimal
+                            *Quantity or price must be valid
                         </Text>
                         <View style={styles.btnContainer}>
                             <TouchableOpacity 

--- a/src/components/ErrorMessageModal.js
+++ b/src/components/ErrorMessageModal.js
@@ -1,0 +1,50 @@
+import Modal from 'react-native-modal';
+import {
+    View,
+    Text,
+    StyleSheet
+} from 'react-native';
+
+const ErrorMessageModal = ({
+    message,
+    isVisible,
+    onClose
+}) => {
+    return (
+        <Modal
+            isVisible={isVisible}
+            onBackButtonPress={onClose}
+            onBackdropPress={onClose}
+            style={styles.modal}>
+            <View style={styles.container}>
+                <Text style={styles.error}>Error</Text>
+                <Text style={styles.message}>{message}</Text>
+            </View>
+        </Modal>
+    )
+}
+
+const styles = StyleSheet.create({
+    container: {
+        width: '80%',
+        height: 150,
+        backgroundColor: 'white',
+        borderRadius: 20,
+        alignItems: 'center',
+    },
+    error: {
+        color: 'red',
+        margin: 10,
+        marginBottom: 20,
+        fontSize: 25
+    },
+    modal: {
+        alignItems: 'center'
+    },
+    message: {
+        fontSize: 15,
+        textAlign: 'center'
+    }
+})
+
+export default ErrorMessageModal;

--- a/src/components/FriendRequest.js
+++ b/src/components/FriendRequest.js
@@ -3,17 +3,17 @@ import {
     View, 
     Text, 
     TouchableOpacity,
+    Image
 } from 'react-native';
-import CachedImage from 'react-native-expo-cached-image';
 
 const FriendRequest = ({ item, declineHandler, acceptHandler, url }) => {
     return (
         <View style={styles.requestContainer}>
             <View style={styles.userDisplay}>
-                <CachedImage
-                    isBackground 
+                <Image
                     source={{ uri: url }} 
                     style={styles.contactImg} 
+                    cache="only-if-cached"
                 />
                 <Text style={styles.name}>
                     {item.from}

--- a/src/components/Greeting.js
+++ b/src/components/Greeting.js
@@ -2,10 +2,10 @@ import {
     StyleSheet, 
     Text,
     View,
+    Image
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import { getCurrentUser } from '../firebase/loginAPI';
-import CachedImage from 'react-native-expo-cached-image';
 
 const Greeting = ({
     cashToReceive,
@@ -19,10 +19,10 @@ const Greeting = ({
 
     return (
         <View style={styles.container}>
-            <CachedImage
-                isBackground
+            <Image
                 style={styles.profileImg} 
                 source={{ uri: photoURI }} 
+                cache="only-if-cached"
             />
             <Text style={styles.greetingTitle}>
                 Welcome Back

--- a/src/components/IncomingSplitRequest.js
+++ b/src/components/IncomingSplitRequest.js
@@ -4,6 +4,7 @@ import {
     Text,
     StyleSheet,
     TouchableOpacity,
+    Image
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
@@ -18,7 +19,6 @@ import {
 import { db } from '../firebase/loginAPI';
 import HorizontalLine from './HorizontalLine';
 import SplitDetailsModal from './SplitDetailsModal';
-import CachedImage from 'react-native-expo-cached-image';
 
 const IncomingSplitRequest = ({ item }) => {
     const profileImgs = useSelector(state => state.users.profilePictures);
@@ -179,10 +179,10 @@ const IncomingSplitRequest = ({ item }) => {
         <View>
             <View style={styles.container}>
                 <View style={styles.requesterContainer}>
-                    <CachedImage
-                        isBackground
+                    <Image
                         source={{ uri: profileImgs[item.from] }}
                         style={styles.requesterImg}
+                        cache="only-if-cached"
                     />
                     <View style={styles.detailsContainer}>
                         <Text style={styles.requesterText}>

--- a/src/components/ItemReceiver.js
+++ b/src/components/ItemReceiver.js
@@ -4,7 +4,8 @@ import {
     Text,
     StyleSheet,
     FlatList,
-    TouchableOpacity
+    TouchableOpacity,
+    Image
 } from 'react-native';
 import { useDispatch } from 'react-redux';
 import { DraxView } from 'react-native-drax';
@@ -15,7 +16,6 @@ import {
     changeRemainingQtyInReceiptItems
 } from '../store/receiptSlice';
 import { Entypo } from '@expo/vector-icons';
-import CachedImage from 'react-native-expo-cached-image';
 
 const ItemReceiver = ({ member, profileImg }) => {
     const dispatch = useDispatch();
@@ -62,10 +62,10 @@ const ItemReceiver = ({ member, profileImg }) => {
     return (
         <View>
             <View style={styles.contact}>
-                <CachedImage
-                    isBackground
+                <Image
                     source={{ uri: profileImg }}
                     style={styles.profileImg}
+                    cache="only-if-cached"
                 />
                 <Text style={styles.emailText}>
                     {member.email}

--- a/src/components/OutgoingSplitRequest.js
+++ b/src/components/OutgoingSplitRequest.js
@@ -3,7 +3,8 @@ import {
     View,
     Text,
     StyleSheet,
-    TouchableOpacity
+    TouchableOpacity,
+    Image
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
@@ -13,7 +14,6 @@ import {
 import { db } from '../firebase/loginAPI';
 import HorizontalLine from './HorizontalLine';
 import SplitDetailsModal from './SplitDetailsModal';
-import CachedImage from 'react-native-expo-cached-image';
 
 const OutgoingSplitRequest = ({ item }) => {
     const profileImgs = useSelector(state => state.users.profilePictures);
@@ -29,10 +29,10 @@ const OutgoingSplitRequest = ({ item }) => {
         <View>
             <View style={styles.container}>
                 <View style={styles.senderContainer}>
-                    <CachedImage
-                        isBackground
+                    <Image
                         source={{ uri: profileImgs[item.to] }}
                         style={styles.profileImg}
+                        cache="only-if-cached"
                     />
                     <View style={styles.senderDetailsContainer}>
                         <Text style={styles.senderText}>

--- a/src/components/ProfileImgPicker.js
+++ b/src/components/ProfileImgPicker.js
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
     StyleSheet, 
     TouchableOpacity,
     View,
+    Image
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import * as ImagePicker from 'expo-image-picker';
@@ -13,13 +14,16 @@ import {
 import { getCurrentUser } from '../firebase/loginAPI';
 import { MaterialIcons } from '@expo/vector-icons';
 import ProfileImgPickerModal from './ProfileImgPickerModal';
-import CachedImage from 'react-native-expo-cached-image';
 
 const ProfileImgPicker = () => {
     const [modalVisible, setModalVisible] = useState(false);
-    
+    const [profileImg, setProfileImg] = useState("https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png")
+
     const profilePictures = useSelector(state => state.users.profilePictures);
-    const photoURI = profilePictures[getCurrentUser()];
+
+    useEffect(() => {
+        setProfileImg(profilePictures[getCurrentUser()]);
+    }, [profilePictures]);
 
     const onImageLibraryPress = async () => {
         try {
@@ -32,6 +36,7 @@ const ProfileImgPicker = () => {
             if (!result.cancelled) {
                 await uploadImg(result.uri);
                 setModalVisible(false);
+                setProfileImg(result.uri);
             }
         } catch (error) {
             console.log(error.message);
@@ -55,6 +60,7 @@ const ProfileImgPicker = () => {
             if (!result.cancelled) {
                 await uploadImg(result.uri);
                 setModalVisible(false);
+                setProfileImg(result.uri);
             }
         } catch (error) {
             console.log(error.message);
@@ -65,6 +71,7 @@ const ProfileImgPicker = () => {
         await deleteProfileImg();
         
         setModalVisible(false);
+        setProfileImg("https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_960_720.png");
     }
     
     return (
@@ -72,10 +79,10 @@ const ProfileImgPicker = () => {
             <TouchableOpacity
                 style={styles.photoFrame}
                 onPress={() => setModalVisible(true)}>
-                <CachedImage
-                    isBackground
+                <Image
                     style={styles.profileImg} 
-                    source={{ uri: photoURI }}
+                    source={{ uri: profileImg }}
+                    cache="only-if-cached"
                 />
                 <View style={styles.pencilContainer}>
                     <MaterialIcons 

--- a/src/components/ScannedItem.js
+++ b/src/components/ScannedItem.js
@@ -23,10 +23,9 @@ const ScannedItem = ({ item, isValidFormInput }) => {
         }
 
         dispatch(editReceiptItem({
-            description,
-            priceChange: parseFloat(parseFloat(price).toFixed(2)),
-            remainingQuantity: parseInt(quantity),
-            initialQuantity: parseInt(quantity),
+            newDescription: description,
+            newPrice: parseFloat(parseFloat(price).toFixed(2)),
+            newQuantity: parseInt(quantity),
             id: itemId,
         }));
 

--- a/src/components/SearchResult.js
+++ b/src/components/SearchResult.js
@@ -3,6 +3,7 @@ import {
     Text,
     StyleSheet,
     TouchableOpacity,
+    Image
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import { 
@@ -12,7 +13,6 @@ import {
     doc
 } from 'firebase/firestore';
 import { getCurrentUser, db } from '../firebase/loginAPI';
-import CachedImage from 'react-native-expo-cached-image';
 
 const SearchResult = ({ user, profilePic }) => {
     const outgoingReqs = useSelector(state => state.friendship.sentFriendRequests);
@@ -53,10 +53,10 @@ const SearchResult = ({ user, profilePic }) => {
     return (
         <View style={styles.searchResult}>
             <View style={styles.userDisplay}>
-                <CachedImage
-                    isBackground
+                <Image
                     source={{ uri: profilePic }} 
-                    style={styles.contactImg} />
+                    style={styles.contactImg} 
+                    cache="only-if-cached" />
                 <Text style={styles.name}>{user.email}</Text>
             </View>
             {

--- a/src/components/SelectedFriend.js
+++ b/src/components/SelectedFriend.js
@@ -1,12 +1,12 @@
 import {
     Text,
     TouchableOpacity,
-    StyleSheet
+    StyleSheet,
+    Image
 } from 'react-native';
 import { Entypo } from '@expo/vector-icons';
 import { useDispatch } from 'react-redux';
 import { removeActiveGroupMember } from '../store/receiptSlice';
-import CachedImage from 'react-native-expo-cached-image';
 
 const SelectedFriends = ({ member, profileImg }) => {
     const dispatch = useDispatch();
@@ -26,10 +26,10 @@ const SelectedFriends = ({ member, profileImg }) => {
                 color="black"
                 style={styles.cross}
             />
-            <CachedImage
-                isBackground
+            <Image
                 source={{ uri: profileImg }}
                 style={styles.profileImg}
+                cache="only-if-cached"
             />
             <Text style={styles.email} ellipsizeMode='tail' numberOfLines={1}>
                 {member.email}

--- a/src/components/SelectedFriend.js
+++ b/src/components/SelectedFriend.js
@@ -1,5 +1,4 @@
 import {
-    View,
     Text,
     TouchableOpacity,
     StyleSheet

--- a/src/firebase/ProfileImgAPI.js
+++ b/src/firebase/ProfileImgAPI.js
@@ -26,8 +26,10 @@ const uploadImg = async uploadURI => {
     const ProfilePictureRef = ref(storageRef, "ProfilePictures/" + getCurrentUser());
     
     uploadBytes(ProfilePictureRef, blob)
-        .then(async () => {
-            await updateURLInFirebase();
+        .then(() => {
+            setTimeout(async () => {
+                await updateURLInFirebase();
+            }, 2000);
         });
 }
 

--- a/src/navigator/BillStack.js
+++ b/src/navigator/BillStack.js
@@ -6,6 +6,7 @@ import {
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import ActiveGroup from '../screens/ActiveGroup';
 import BillVerification from '../screens/BillVerification';
+import FriendsSearchBar from '../screens/FriendsSearchBar';
 import ScannedItems from '../screens/ScannedItems';
 import SplitItems from '../screens/SplitItems';
 import SplitBillHeader from './SplitBillHeader';
@@ -79,6 +80,13 @@ const BillStack = () => {
                 component={BillVerification}
                 options={{
                     title: "Bill Verification"
+                }}
+            />
+            <Stack.Screen 
+                name="SendFriendRequest" 
+                component={FriendsSearchBar} 
+                options={{
+                    headerTitle: 'Send Friend Request'
                 }}
             />
         </Stack.Navigator>

--- a/src/navigator/FriendsStack.js
+++ b/src/navigator/FriendsStack.js
@@ -30,6 +30,9 @@ const FriendsStack = () => {
             <Stack.Screen 
                 name="Add Friends" 
                 component={FriendsSearchBar} 
+                options={{
+                    headerTitle: 'Send Friend Request'
+                }}
             />
         </Stack.Navigator>
     );

--- a/src/screens/ActiveGroup.js
+++ b/src/screens/ActiveGroup.js
@@ -6,7 +6,7 @@ import {
     FlatList,
     TouchableOpacity
 } from 'react-native';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import ActiveGroupContact from '../components/ActiveGroupContact';
 import ActiveGroupSearchBar from '../components/ActiveGroupSearchBar';
 import HorizontalLine from '../components/HorizontalLine';

--- a/src/screens/ActiveGroup.js
+++ b/src/screens/ActiveGroup.js
@@ -1,34 +1,24 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import {
     View,
     Text,
     StyleSheet,
-    FlatList
+    FlatList,
+    TouchableOpacity
 } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
-import { 
-    emptyActiveGroupMembers,
-    resetReceiptRemainingToInitial 
-} from '../store/receiptSlice';
 import ActiveGroupContact from '../components/ActiveGroupContact';
 import ActiveGroupSearchBar from '../components/ActiveGroupSearchBar';
 import HorizontalLine from '../components/HorizontalLine';
 import SelectedFriend from '../components/SelectedFriend';
 
-const ActiveGroup = () => {
-    const dispatch = useDispatch();
-
+const ActiveGroup = ({ navigation }) => {
     const friendsEmail = useSelector(state => state.friendship.friendsEmail);
     const profileImgs = useSelector(state => state.users.profilePictures);
     const activeGroupMembers = useSelector(state => state.receipt.activeGroupMembers);
     
     const [filteredFriends, setFilteredFriends] = useState(friendsEmail);
-
-    useEffect(() => {
-        dispatch(emptyActiveGroupMembers());
-        dispatch(resetReceiptRemainingToInitial());
-    }, []);
-
+    
     return (
         <View style={styles.container}>
             <ActiveGroupSearchBar
@@ -52,25 +42,39 @@ const ActiveGroup = () => {
                 <HorizontalLine />
             </View>
             {
-                filteredFriends.length === 0
+                friendsEmail.length === 0
                     ? (
-                        <Text style={styles.noResultText}>
-                            No Search Results...
-                        </Text>
-                    )
-                    : (
-                        <FlatList
-                            keyExtractor={item => item}
-                            data={filteredFriends}
-                            renderItem={({ item }) => (
-                                <ActiveGroupContact 
-                                    email={item}
-                                    profileImg={profileImgs[item]}
-                                    activeGroupMembers={activeGroupMembers}
-                                />
-                            )}
-                        />
-                    )
+                        <View style={styles.noFriendsContainer}>
+                            <Text style={styles.noResultText}>
+                                You do not have friends yet...
+                            </Text>
+                            <TouchableOpacity style={styles.navigateBtn}
+                                onPress={() => navigation.navigate("SendFriendRequest")}>
+                                <Text style={styles.navigateLink}>
+                                    Click to Add Friends
+                                </Text>
+                            </TouchableOpacity>
+                        </View>
+                    ) 
+                    : filteredFriends.length === 0
+                        ? (
+                            <Text style={styles.noResultText}>
+                                No Search Results...
+                            </Text>
+                        )
+                        : (
+                            <FlatList
+                                keyExtractor={item => item}
+                                data={filteredFriends}
+                                renderItem={({ item }) => (
+                                    <ActiveGroupContact 
+                                        email={item}
+                                        profileImg={profileImgs[item]}
+                                        activeGroupMembers={activeGroupMembers}
+                                    />
+                                )}
+                            />
+                        )
             }
         </View>
     )
@@ -81,10 +85,21 @@ const styles = StyleSheet.create({
         flex: 1,
         backgroundColor: 'white'
     },
+    navigateLink: {
+        color: 'rgb(10, 132, 255)',
+        fontSize: 18,
+        marginTop: 10,
+        fontStyle: 'italic',
+        fontWeight: '200'
+    },
+    noFriendsContainer: {
+        alignItems: 'center'
+    },
     noResultText: {
         marginTop: 50,
         fontSize: 18,
-        textAlign: 'center'
+        fontStyle: "italic",
+        fontWeight: '200'
     }
 })
 

--- a/src/screens/FriendsSearchBar.js
+++ b/src/screens/FriendsSearchBar.js
@@ -74,6 +74,9 @@ const FriendsSearchBar = () => {
                     style={styles.searchText}
                     onChangeText={text => setFilteredUsers(filterUsers(text))}
                     placeholder="Search For Friends"
+                    autoCapitalize='none'
+                    autoComplete='off'
+                    autoCorrect={false}
                 />
             </View>
             <HorizontalLine />

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { 
     View,
     StyleSheet,
-    ScrollView
+    ScrollView,
 } from 'react-native';
 import { useDispatch } from 'react-redux';
 import { 

--- a/src/screens/Login.js
+++ b/src/screens/Login.js
@@ -69,12 +69,18 @@ const Login = ({ navigation }) => {
                             onChangeText={input => setEmail(input)}
                             keyboardType="email-address"
                             placeholder="Enter your email address"
+                            autoCapitalize='none'
+                            autoComplete='off'
+                            autoCorrect={false}
                         />
                         <TextInput
                             style={AuthStyles.textInput}
                             onChangeText={input => setPassword(input)}
                             placeholder="Enter your password"
                             secureTextEntry
+                            autoCapitalize='none'
+                            autoComplete='off'
+                            autoCorrect={false}
                         />
                         <TouchableOpacity
                             style={AuthStyles.blueBGBtn}

--- a/src/screens/ScannedItems.js
+++ b/src/screens/ScannedItems.js
@@ -9,7 +9,8 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import {
     addReceiptItem,
-    setReceiptItems
+    setReceiptItems,
+    emptyReceiptStore
 } from '../store/receiptSlice';
 import AddItemModal from '../components/AddItemModal';
 import ScannedItem from '../components/ScannedItem';
@@ -35,6 +36,8 @@ const ScannedItems = ({ route }) => {
                 id: Math.random(1000)
             })
         }
+
+        dispatch(emptyReceiptStore());
 
         dispatch(setReceiptItems({
             receiptItems: initialItems

--- a/src/screens/ScannedItems.js
+++ b/src/screens/ScannedItems.js
@@ -64,10 +64,22 @@ const ScannedItems = ({ route }) => {
             return false;
         }
 
+        for (let i = 0; i < quantity.length; i++) {
+            if (quantity.charAt(i) === ',' || quantity.charAt(i) === "." ||
+                quantity.charAt(i) === " " || quantity.charAt(i) === "-") {
+                return false;
+            }
+        }
+
         let dotCount = 0;
         for (let i = 0; i < price.length; i++) {
             if (price.charAt(i) === ".") {
                 dotCount++;
+            }
+
+            if (price.charAt(i) === "," || price.charAt(i) === "-" ||
+                price.charAt(i) === " ") {
+                return false;
             }
         }
 

--- a/src/screens/Signup.js
+++ b/src/screens/Signup.js
@@ -86,18 +86,27 @@ const Signup = ({ navigation }) => {
                             onChangeText={input => setEmail(input)}
                             keyboardType="email-address"
                             placeholder="Enter your email address"
+                            autoCapitalize='none'
+                            autoComplete='off'
+                            autoCorrect={false}
                         />
                         <TextInput
                             style={AuthStyles.textInput}
                             onChangeText={input => setPassword(input)}
                             placeholder="Enter your password"
                             secureTextEntry
+                            autoCapitalize='none'
+                            autoComplete='off'
+                            autoCorrect={false}
                         />
                         <TextInput
                             style={AuthStyles.textInput}
                             onChangeText={input => setConfirmPassword(input)}
                             placeholder="Confirm Password"
                             secureTextEntry
+                            autoCapitalize='none'
+                            autoComplete='off'
+                            autoCorrect={false}
                         />
                         <TouchableOpacity 
                             style={AuthStyles.blueBGBtn}
@@ -110,7 +119,9 @@ const Signup = ({ navigation }) => {
                         <TouchableOpacity 
                             style={AuthStyles.blueBGBtn}
                             onPress={() => navigation.navigate("Login")}>
-                            <Text style={AuthStyles.buttonText}>Go back to sign in</Text>
+                            <Text style={AuthStyles.buttonText}>
+                                Go back to sign in
+                            </Text>
                         </TouchableOpacity>
                     </View>
                 </View>

--- a/src/screens/SplitItems.js
+++ b/src/screens/SplitItems.js
@@ -2,7 +2,6 @@ import {
     View,
     Text,
     StyleSheet,
-    FlatList,
     ScrollView
 } from 'react-native';
 import { DraxProvider, DraxList } from 'react-native-drax';
@@ -63,7 +62,6 @@ const SplitItems = () => {
                             : (
                                 receivingItemList.map(item => (
                                     <ItemReceiver
-                                        draggableItems={draggableItems}
                                         member={item}
                                         profileImg={profileImgs[item.email]}
                                         key={item.email}
@@ -73,8 +71,7 @@ const SplitItems = () => {
                     }
                 </ScrollView>
             </DraxProvider>
-
-            </GestureHandlerRootView>
+        </GestureHandlerRootView>
     );
 };
 

--- a/src/store/receiptSlice.js
+++ b/src/store/receiptSlice.js
@@ -62,6 +62,14 @@ export const receiptSlice = createSlice({
         },
         deleteReceiptItem: (state, action) => {
             const index = state.receiptItems.findIndex(item => item.id === action.payload.id);
+
+            state.activeGroupMembers = state.activeGroupMembers.map(member => {
+                return {
+                    ...member,
+                    items: member.items.filter(item => item.id !== action.payload.id)
+                }
+            })
+
             state.receiptItems = [
                 ...state.receiptItems.slice(0, index),
                 ...state.receiptItems.slice(index + 1)

--- a/src/store/receiptSlice.js
+++ b/src/store/receiptSlice.js
@@ -1,9 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 /*
-    activeGroupMembers: [ { email: 'test1@test.com', items: [ { id: 32131, description: 'nuggets', priceShare: 4.32, quantity: 3 }, ... ], totalPrice: 9.43 }, ... ]
+    activeGroupMembers: [ { email: 'test1@test.com', items: [ { id: 32131, description: 'nuggets', quantity: 3 }, ... ] }, ... ]
     receiptItems: [{ id: 2, description: 'Nuggets', remainingQuantity: 6, initialQuantity: 6, price: 7.20 }, ... ]
-*/
+    */
 const initialState = {
     activeGroupMembers: [],
     receiptItems: [],
@@ -13,6 +13,60 @@ export const receiptSlice = createSlice({
     name: 'receipt',
     initialState,
     reducers: {
+        addReceiptItem: (state, action) => {
+            state.receiptItems = [
+                ...state.receiptItems,
+                action.payload.newItem
+            ];
+        },
+        setReceiptItems: (state, action) => {
+            state.receiptItems = action.payload.receiptItems;
+        },
+        editReceiptItem: (state, action) => {
+            state.receiptItems = state.receiptItems.map(item => {
+                if (item.id === action.payload.id) {
+                    const initialQtyChange = action.payload.newQuantity - item.initialQuantity;
+
+                    if (initialQtyChange < 0) {
+                        // Remove item that is edited from all active group members
+                        state.activeGroupMembers = state.activeGroupMembers.map(member => {
+                            return {
+                                ...member,
+                                items: member.items.filter(memberItem => {
+                                    return memberItem.description !== item.description
+                                })
+                            }
+                        });
+
+                        // Return new item with all updated fields
+                        return {
+                            ...item,
+                            description: action.payload.newDescription,
+                            price: action.payload.newPrice,
+                            remainingQuantity: action.payload.newQuantity,
+                            initialQuantity: action.payload.newQuantity
+                        }
+                    }
+                    
+                    return {
+                        ...item,
+                        description: action.payload.newDescription,
+                        price: action.payload.newPrice,
+                        remainingQuantity: item.remainingQuantity + initialQtyChange,
+                        initialQuantity: action.payload.newQuantity
+                    }
+                }
+                
+                return item;
+            })
+        },
+        deleteReceiptItem: (state, action) => {
+            const index = state.receiptItems.findIndex(item => item.id === action.payload.id);
+            state.receiptItems = [
+                ...state.receiptItems.slice(0, index),
+                ...state.receiptItems.slice(index + 1)
+            ];
+        },
         addActiveGroupMember: (state, action) => {
             state.activeGroupMembers = [ 
                 ...state.activeGroupMembers, 
@@ -23,6 +77,23 @@ export const receiptSlice = createSlice({
             const removeIndex = state.activeGroupMembers.findIndex(member => {
                 return member.email === action.payload.memberToRemove;
             });
+
+            const memberItems = state.activeGroupMembers[removeIndex].items;
+
+            state.receiptItems = state.receiptItems.map(item => {
+                const itemIndex = memberItems.findIndex(memberItem => {
+                    return memberItem.description === item.description
+                });
+
+                if (itemIndex !== -1) {
+                    return {
+                        ...item,
+                        remainingQuantity: item.remainingQuantity + memberItems[itemIndex].quantity
+                    }
+                }
+
+                return item;
+            })
 
             state.activeGroupMembers = [
                 ...state.activeGroupMembers.slice(0, removeIndex),
@@ -38,35 +109,47 @@ export const receiptSlice = createSlice({
                         return item.description === newItem.description;
                     });
 
+                    // Item is not in items array of active group member.
                     if (itemIndex === -1) {
                         return {
-                            email: member.email,
+                            ...member,
                             items: [
                                 ...member.items,
                                 newItem
-                            ],
-                            totalPrice: member.totalPrice + newItem.priceShare
+                            ]
                         }
                     }
 
                     return {
-                        email: member.email,
+                        ...member,
                         items: member.items.map(item => {
                             if (item.description === newItem.description) {
                                 return {
                                     ...newItem,
-                                    quantity: member.items[itemIndex].quantity + newItem.quantity,
-                                    priceShare: item.priceShare + newItem.priceShare
+                                    quantity: item.quantity + newItem.quantity,
                                 }
                             }
 
                             return item;
                         }),
-                        totalPrice: member.totalPrice + newItem.priceShare
                     }
                 }
 
                 return member;
+            })
+        },
+        changeRemainingQtyInReceiptItems: (state, action) => {
+            state.receiptItems = state.receiptItems.map(item => {
+                if (item.id === action.payload.itemId) {
+                    return {
+                        ...item,
+                        remainingQuantity: action.payload.method === "DECREMENT"
+                            ? item.remainingQuantity - action.payload.qtyChange
+                            : item.remainingQuantity + action.payload.qtyChange
+                    }
+                }
+
+                return item;
             })
         },
         deleteItemFromMember: (state, action) => {
@@ -75,87 +158,29 @@ export const receiptSlice = createSlice({
                     return {
                         ...member,
                         items: member.items.filter(item => item.id !== action.payload.itemId),
-                        totalPrice: action.payload.totalPrice
                     }
                 }
 
                 return member;
             })
         },
-        addReceiptItem: (state, action) => {
-            state.receiptItems = [
-                ...state.receiptItems,
-                action.payload.newItem
-            ];
-        },
-        editReceiptItem: (state, action) => {
-            state.receiptItems = state.receiptItems.map(item => {
-                if (item.id === action.payload.id) {
-                    return {
-                        description: action.payload.description,
-                        price: action.payload.priceChange,
-                        remainingQuantity: action.payload.remainingQuantity,
-                        initialQuantity: action.payload.initialQuantity,
-                        id: item.id,
-                    }
-                }
-
-                return item;
-            })
-        },
-        changeReceiptItemPriceAndRemainingQty: (state, action) => {
-            state.receiptItems = state.receiptItems.map(item => {
-                if (item.id === action.payload.id) {
-                    return {
-                        ...item,
-                        remainingQuantity: action.payload.remainingQuantity,
-                        priceChange: action.payload.priceChange + item.price
-                    };
-                }
-
-                return item;
-            });
-        },
-        deleteReceiptItem: (state, action) => {
-            const index = state.receiptItems.findIndex(item => item.id === action.payload.id);
-            state.receiptItems = [
-                ...state.receiptItems.slice(0, index),
-                ...state.receiptItems.slice(index + 1)
-            ];
-        },
-        setReceiptItems: (state, action) => {
-            state.receiptItems = action.payload.receiptItems;
-        },
         emptyReceiptStore: state => {
             state.receiptItems = [];
             state.activeGroupMembers = [];
         },
-        emptyActiveGroupMembers: state => {
-            state.activeGroupMembers = [];
-        },
-        resetReceiptRemainingToInitial: state => {
-            state.receiptItems = state.receiptItems.map(item => {
-                return {
-                    ...item,
-                    remainingQuantity: item.initialQuantity
-                };
-            });
-        } 
     }
 });
 
 export const {
+    addReceiptItem,
+    setReceiptItems,
+    editReceiptItem,
+    deleteReceiptItem,
     addActiveGroupMember,
     removeActiveGroupMember,
     addItemToMember,
-    addReceiptItem,
-    editReceiptItem,
+    changeRemainingQtyInReceiptItems,
     deleteItemFromMember,
-    deleteReceiptItem,
-    changeReceiptItemPriceAndRemainingQty,
-    setReceiptItems,
     emptyReceiptStore,
-    emptyActiveGroupMembers,
-    resetReceiptRemainingToInitial
 } = receiptSlice.actions;
 export default receiptSlice.reducer;


### PR DESCRIPTION
Split bill page now saves state such that whenever you press back, when you return, the data is not lost (i.e. selected group member and items).

Profile picture now changes instantly through the help of useState hook.

Confirm split and delete friend button now added requirements to prevent error.
Confirm split requires that there are some members and items part of the split bill. Members with $0 share is not sent a split bill request.

Delete friend functionality now requires no debts between friends before deletion is allowed (i.e. only when $0, can delete).

Fixed a bug on clicking circle to select members.